### PR TITLE
🔥 Remove support for Python 2.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,6 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python2.7
-            python_version: "2.7"
           - name: python3.9-alpine3.13
             python_version: "3.9"
           - name: python3.8-alpine3.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python2.7
-            python_version: "2.7"
           - name: python3.9-alpine3.13
             python_version: "3.9"
           - name: python3.8-alpine3.11

--- a/README.md
+++ b/README.md
@@ -10,13 +10,20 @@
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/meinheld-gunicorn-docker/blob/master/docker-images/python3.7-alpine3.8.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/meinheld-gunicorn-docker/blob/master/docker-images/python3.6.dockerfile)
 * [`python3.6-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/meinheld-gunicorn-docker/blob/master/docker-images/python3.6-alpine3.8.dockerfile)
+
+## Deprecated
+
+These tags are no longer supported:
+
 * [`python2.7` _(Dockerfile)_](https://github.com/tiangolo/meinheld-gunicorn-docker/blob/master/docker-images/python2.7.dockerfile)
+
+---
 
 **Note**: There are [tags for each build date](https://hub.docker.com/r/tiangolo/meinheld-gunicorn/tags). If you need to "pin" the Docker image version you use, you can select one of those tags. E.g. `tiangolo/meinheld-gunicorn:python3.7-2019-10-15`.
 
 # meinheld-gunicorn
 
-[**Docker**](https://www.docker.com/) image with [**Meinheld**](http://meinheld.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance web applications in **[Python](https://www.python.org/) 3.6** and above and **Python 2.7**, with performance auto-tuning. Optionally with Alpine Linux.
+[**Docker**](https://www.docker.com/) image with [**Meinheld**](http://meinheld.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance web applications in **[Python](https://www.python.org/)**, with performance auto-tuning. Optionally with Alpine Linux.
 
 **GitHub repo**: [https://github.com/tiangolo/meinheld-gunicorn-docker](https://github.com/tiangolo/meinheld-gunicorn-docker)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "meinheld-gunicorn-docker"
 version = "0.1.0"
-description = "Docker image with Meinheld managed by Gunicorn for high-performance web applications in Python 3.6 and above and Python 2.7, with performance auto-tuning. Optionally with Alpine Linux."
+description = "Docker image with Meinheld managed by Gunicorn for high-performance web applications in Python with performance auto-tuning. Optionally with Alpine Linux."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 license = "MIT"
 

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -8,7 +8,6 @@ environments = [
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
-    {"NAME": "python2.7", "PYTHON_VERSION": "2.7"},
     {"NAME": "python3.9-alpine3.13", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-alpine3.11", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7-alpine3.8", "PYTHON_VERSION": "3.7"},


### PR DESCRIPTION
🔥 Remove support for Python 2.7

---

The official Python image docs no longer list Python 2.7: https://hub.docker.com/_/python

The latest version of the official Python image tag for Python 2.7 was pushed a year ago: https://hub.docker.com/layers/python/library/python/2.7-buster/images/sha256-de52085267e18aba7083768f283765fcd04f753aba32cc85e62a39c77670cf4b?context=explore

And I have no particular interest in supporting Python 2.7 (I don't use it, for several years ago).